### PR TITLE
Add a little bit more flexibility on the msg format

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ Getting started
     <al-bot-test> leamas: The operation succeeded.
 ```
 
+* By default irccat will use *notice* messages, but some users will prefer
+  to use *privmsg* messages. To do so (still in private window):
+```
+     <leamas> config plugins.irccat.privmsg True
+     <al-bot-test> The operation succeeded.
+```
+
 * Your bot must join the channel(s) you want to feed. Do this with
   `join`, still in private window:
 ```

--- a/config.py
+++ b/config.py
@@ -62,4 +62,7 @@ conf.registerGlobalValue(Irccat, 'port',
     registry.NonNegativeInteger(12345,
                                 "The TCP port irccat will listen to."))
 
+conf.registerGlobalValue(Irccat, 'privmsg',
+    registry.Boolean(False, 'Use privmsgs instead of the default notices'))
+
 # vim:set shiftwidth=4 tabstop=4 expandtab textwidth=79:

--- a/plugin.py
+++ b/plugin.py
@@ -133,6 +133,7 @@ class _Config(object):
 
     def __init__(self):
         self.port = config.global_option('port').value
+        self.privmsg = config.global_option('privmsg').value
         self._path = config.global_option('sectionspath').value
         try:
             self._data = pickle.load(open(self._path))
@@ -277,7 +278,10 @@ class Irccat(callbacks.Plugin):
                 msg, channels = self.pipe[1].recv()
                 for channel in channels:
                     if channel in self.irc.state.channels:
-                        self.irc.queueMsg(ircmsgs.notice(channel, msg))
+                        if self.config.privmsg:
+                            self.irc.queueMsg(ircmsgs.privmsg(channel, msg))
+                        else:
+                            self.irc.queueMsg(ircmsgs.notice(channel, msg))
                     else:
                         self.log.warning(
                             "Can't write to non-joined channel: " + channel)


### PR DESCRIPTION
Hi,

As per a similar plugin (https://github.com/tbielawa/supybot-mailed-notifier) I wanted the option to use privmsgs rather than notices for the messages I sent.

So I added an option.

All the best

Col
